### PR TITLE
Add explicit allowed-origins options for '*' and matching any origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Receives 2 arguments:
   - `:allowed-origins`
 
     A set that specifies which origins are allowed by the
-    middleware. A value of nil indicates unrestricted cross-origin
+    middleware. A value of `:star-origin` indicates unrestricted cross-origin
     sharing and results in `*` as value for the
     `Access-Control-Allow-Origin` HTTP response header.
+    A value of `:match-origin` will always return the incoming origin header.
 
   - `:allowed-methods`
 

--- a/src/com/unbounce/encors/core.clj
+++ b/src/com/unbounce/encors/core.clj
@@ -15,7 +15,7 @@
 ;; Origin -> CorsPolicy -> Headers
 (defn cors-common-headers [origin cors-policy]
   (if (or (nil? origin)
-          (nil? (:allowed-origins cors-policy)))
+          (= (:allowed-origins cors-policy) types/star-origin))
     ;; ^ At this point we already validated all cases where either
     ;; of this two being nil is an *error*
     (merge {"Access-Control-Allow-Origin" "*"}
@@ -122,9 +122,10 @@
 
     (cond
       ;;
-      (or (and allowed-origins
-               (contains? allowed-origins origin))
-          (nil? allowed-origins))
+      (or
+       (= allowed-origins types/match-origin)
+       (= allowed-origins types/star-origin)
+       (contains? allowed-origins origin))
 
       ;; check if it is a preflight request
       (if (= :options (get req :request-method))

--- a/src/com/unbounce/encors/types.clj
+++ b/src/com/unbounce/encors/types.clj
@@ -1,8 +1,13 @@
 (ns com.unbounce.encors.types
   (:require [schema.core :as s]))
 
+(def match-origin :match-origin)
+
+(def star-origin :star-origin)
+
 (def CorsPolicySchema
-  {(s/required-key :allowed-origins)    (s/maybe #{s/Str})
+  {(s/required-key :allowed-origins)    (s/either #{s/Str}
+                                                  (s/enum match-origin star-origin))
    (s/required-key :allowed-methods)    #{(s/enum :head :options :get
                                                   :post :put :delete :patch :trace)}
    (s/required-key :request-headers)    #{s/Str}

--- a/test/com/unbounce/encors/core_test.clj
+++ b/test/com/unbounce/encors/core_test.clj
@@ -125,9 +125,20 @@
                       "Access-Control-Max-Age" "365"}])))))
 
 (deftest apply-cors-policy-test
-  (testing ":allowed-origins has a nil value"
+  (testing ":allowed-origins has a :star-origin value"
     (let [policy (merge default-cors-options
-                        {:allowed-origins nil
+                        {:allowed-origins types/star-origin
+                         :origin-varies? false})
+          response (apply-cors-policy {:req {}
+                                       :app (constantly {:status 200 :headers {} :body "test is alright"})
+                                       :origin nil
+                                       :cors-policy policy})]
+      (is (= (:status response) 200))
+      (is (= (:headers response) {"Access-Control-Allow-Origin" "*"}))
+      (is (= (:body response) "test is alright"))))
+  (testing ":allowed-origins has a :star-origin value"
+    (let [policy (merge default-cors-options
+                        {:allowed-origins types/star-origin
                          :origin-varies? false})
           response (apply-cors-policy {:req {}
                                        :app (constantly {:status 200 :headers {} :body "test is alright"})
@@ -135,4 +146,15 @@
                                        :cors-policy policy})]
       (is (= (:status response) 200))
       (is (= (:headers response) {"Access-Control-Allow-Origin" "*"}))
+      (is (= (:body response) "test is alright"))))
+  (testing ":allowed-origins has a :match-origin value"
+    (let [policy (merge default-cors-options
+                        {:allowed-origins types/match-origin
+                         :origin-varies? false})
+          response (apply-cors-policy {:req {}
+                                       :app (constantly {:status 200 :headers {} :body "test is alright"})
+                                       :origin "http://foobar.com"
+                                       :cors-policy policy})]
+      (is (= (:status response) 200))
+      (is (= (:headers response) {"Access-Control-Allow-Origin" "http://foobar.com"}))
       (is (= (:body response) "test is alright")))))


### PR DESCRIPTION
This change is necessary to use credentials with any origin. Using
`Access-Control-Allow-Credentials: true` and
`Access-Control-Allow-Origin: *` is not valid per the spec. To permit
credentials, the exact origin needs to be returned in
`Access-Control-Allow-Origin`. To acheive this we've added the
`:match-origin` option which will always return the provided Origin
header. To make things more explicit, an option `:star-origin` was added
which matches the current behaviour of `nil`. `nil` is no longer a valid
option for `:allowed-origins`.