### PR TITLE
Add Origin as a default valid Access-Control-Request-Headers header.

### DIFF
--- a/src/com/unbounce/encors/types.clj
+++ b/src/com/unbounce/encors/types.clj
@@ -21,6 +21,6 @@
 
 (def simple-methods #{:get :head :post})
 
-(def simple-headers #{"Accept" "Accept-Language" "Content-Language" "Content-Type"})
+(def simple-headers #{"Accept" "Accept-Language" "Content-Language" "Content-Type" "Origin"})
 
-(def simple-headers-wo-content-type #{"Accept" "Accept-Language" "Content-Language"})
+(def simple-headers-wo-content-type #{"Accept" "Accept-Language" "Content-Language" "Origin"})

--- a/test/com/unbounce/encors/core_test.clj
+++ b/test/com/unbounce/encors/core_test.clj
@@ -93,7 +93,7 @@
              [:left [(str "HTTP headers requested in Access-Control-Request-Headers of "
                           "CORS request is not supported; requested: "
                           "'X-Not-Safe-To-Expose, X-Blah-Bleh'; "
-                          "supported are 'X-Safe-To-Expose, Accept-Language, "
+                          "supported are 'X-Safe-To-Expose, Origin, Accept-Language, "
                           "Content-Language, Accept'.")]])))
     (testing "Access-Control-Request-Headers match policy request headers"
       (is (= (cors-preflight-check-request-headers

--- a/test/com/unbounce/encors/integration_test.clj
+++ b/test/com/unbounce/encors/integration_test.clj
@@ -49,7 +49,7 @@
 (def ^:const allowed-methods "GET, HEAD, PATCH, POST")
 (def ^:const allowed-headers "Content-Type, X-Allowed")
 (def ^:const active-allowed-headers
-  "Accept-Language, Content-Language, Content-Type, Accept, X-Allowed")
+  "Origin, Accept-Language, Content-Language, Content-Type, Accept, X-Allowed")
 (def ^:const expose-headers  "X-Safe-To-Expose, X-Safe-To-Expose-Too")
 (def ^:const unallowed-origin "not.cool.io")
 


### PR DESCRIPTION
Safari always sends "origin" as one of the
Access-Control-Request-Headers, so we should accept that as valid by
default.