### PR TITLE
Bump Dependencies with Lein Ancient

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,25 +1,22 @@
-(def ring-version "1.3.2")
-
 (defproject com.unbounce/encors "2.2.2-SNAPSHOT"
   :description "encors is a CORS library for ring"
   :url "https://www.github.com/unbounce/encors"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"
-            :comments "Copyright (c) 2014-2015 Unbounce Marketing Solutions Inc."}
+            :comments "Copyright (c) 2014-2016 Unbounce Marketing Solutions Inc."}
 
-  :profiles {:dev {:plugins [[lein-kibit "0.0.8"]
-                             [jonase/eastwood "0.2.1"]]
-                   :dependencies [[clj-http "1.1.2"]
-                                  [ring/ring-jetty-adapter ~ring-version]
-                                  [compojure "1.3.4"]]}}
+  :profiles {:dev {:plugins [[lein-kibit "0.1.2"]
+                             [jonase/eastwood "0.2.3"]]
+                   :dependencies [[clj-http "2.1.0"]
+                                  [ring/ring-jetty-adapter "1.4.0"]
+                                  [compojure "1.4.0"]]}}
 
   ; set to true to have verbose debug of integration tests
   :jvm-opts ["-Ddebug=false"]
 
   :eastwood {:exclude-namespaces [com.unbounce.encors]}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [potemkin "0.3.13"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.match "0.2.2"]
-                 [prismatic/schema "0.4.3"]
-                 [ring/ring-core ~ring-version]])
+                 [prismatic/schema "1.0.5"]
+                 [potemkin "0.4.3"]])

--- a/src/com/unbounce/encors/types.clj
+++ b/src/com/unbounce/encors/types.clj
@@ -6,8 +6,9 @@
 (def star-origin :star-origin)
 
 (def CorsPolicySchema
-  {(s/required-key :allowed-origins)    (s/either #{s/Str}
-                                                  (s/enum match-origin star-origin))
+  {(s/required-key :allowed-origins)    (s/conditional
+                                          keyword? (s/enum match-origin star-origin)
+                                          set? #{s/Str})
    (s/required-key :allowed-methods)    #{(s/enum :head :options :get
                                                   :post :put :delete :patch :trace)}
    (s/required-key :request-headers)    #{s/Str}


### PR DESCRIPTION
Tests still pass. We use `schema.core` very lightly and there's no changes to the API other than some deprecations.
