### PR TITLE
Add optional aleph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Yet again another [CORS](http://www.w3.org/TR/cors/) library for ring.
 
 ## Usage
 
-Add CORS support to ring apps, this middleware provides:
+Add CORS support to ring apps, supporting both synchronous and asynchronous
+([aleph](https://github.com/ztellman/aleph)) handlers.
 
 ### `wrap-cors`
 
@@ -117,8 +118,15 @@ Example:
 (def app (wrap-cors raw-app cors-policy))
 ```
 
+### `com.unbounce.encors.aleph/wrap-cors`
+
+Same as `wrap-cors`, but supports aleph's deferred responses.
+
+NOTE: This is only avaiable if you have
+[ztellman/aleph](https://github.com/ztellman/aleph) on the classpath.
+
 ## License
 
-Copyright © 2014-2015 Unbounce Marketing Solutions Inc.
+Copyright © 2014-2016 Unbounce Marketing Solutions Inc.
 
 Distributed under the [MIT License (MIT)](http://opensource.org/licenses/MIT).

--- a/project.clj
+++ b/project.clj
@@ -1,25 +1,26 @@
-(def ring-version "1.3.2")
+(def ring-version "1.4.0")
 
 (defproject com.unbounce/encors "2.3.0-SNAPSHOT"
   :description "encors is a CORS library for ring"
   :url "https://www.github.com/unbounce/encors"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"
-            :comments "Copyright (c) 2014-2015 Unbounce Marketing Solutions Inc."}
+            :comments "Copyright (c) 2014-2016 Unbounce Marketing Solutions Inc."}
 
-  :profiles {:dev {:plugins [[lein-kibit "0.0.8"]
-                             [jonase/eastwood "0.2.1"]]
-                   :dependencies [[clj-http "1.1.2"]
+  :profiles {:dev {:plugins [[lein-kibit "0.1.2"]
+                             [jonase/eastwood "0.2.3"]]
+                   :dependencies [[clj-http "3.2.0"]
                                   [ring/ring-jetty-adapter ~ring-version]
-                                  [compojure "1.3.4"]]}}
+                                  [compojure "1.4.0"]
+                                  [manifold "0.1.5"]]}}
 
   ; set to true to have verbose debug of integration tests
   :jvm-opts ["-Ddebug=false"]
 
   :eastwood {:exclude-namespaces [com.unbounce.encors]}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [potemkin "0.3.13"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [potemkin "0.4.3"]
                  [org.clojure/core.match "0.2.2"]
-                 [prismatic/schema "0.4.3"]
+                 [prismatic/schema "1.1.3"]
                  [ring/ring-core ~ring-version]])

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def ring-version "1.3.2")
 
-(defproject com.unbounce/encors "2.2.2-SNAPSHOT"
+(defproject com.unbounce/encors "2.3.0-SNAPSHOT"
   :description "encors is a CORS library for ring"
   :url "https://www.github.com/unbounce/encors"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
   ; set to true to have verbose debug of integration tests
   :jvm-opts ["-Ddebug=false"]
 
-  :eastwood {:exclude-namespaces [com.unbounce.encors]}
+  :eastwood {:exclude-linters [:constant-test]}
 
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [potemkin "0.4.3"]

--- a/src/com/unbounce/encors/aleph.clj
+++ b/src/com/unbounce/encors/aleph.clj
@@ -1,0 +1,14 @@
+(ns com.unbounce.encors.aleph
+  "CORS Middleware with aleph deferred support.
+
+  This namespace requires you to have aleph/manifold on the classpath."
+  (:require [manifold.deferred :as d]
+            [com.unbounce.encors.core :as core]))
+
+(defn wrap-cors
+  [handler cors-policy]
+  (core/build-cors-wrapper handler cors-policy
+                           (fn -apply-deferred-headers [response headers]
+                             (if (d/deferred? response)
+                               (d/chain' response #(core/apply-ring-headers % headers))
+                               (core/apply-ring-headers response headers)))))

--- a/src/com/unbounce/encors/types.clj
+++ b/src/com/unbounce/encors/types.clj
@@ -5,9 +5,9 @@
 
 (def star-origin :star-origin)
 
-(def CorsPolicySchema
-  {(s/required-key :allowed-origins)    (s/either #{s/Str}
-                                                  (s/enum match-origin star-origin))
+(s/defschema CorsPolicySchema
+  {(s/required-key :allowed-origins)    (s/cond-pre (s/enum match-origin star-origin)
+                                                    #{s/Str})
    (s/required-key :allowed-methods)    #{(s/enum :head :options :get
                                                   :post :put :delete :patch :trace)}
    (s/required-key :request-headers)    #{s/Str}

--- a/test/com/unbounce/encors/aleph_test.clj
+++ b/test/com/unbounce/encors/aleph_test.clj
@@ -1,0 +1,30 @@
+(ns com.unbounce.encors.aleph-test
+  (:require [clojure.test :refer :all]
+            [com.unbounce.encors.aleph :as sut]
+            [manifold.deferred :as d]))
+
+(deftest wrap-cors-aleph-test
+  (let [cors-policy       {:allowed-origins    #{"foo"}
+                           :allowed-methods    #{:get}
+                           :exposed-headers    #{"some-header"}
+                           :request-headers    #{}
+                           :max-age            nil
+                           :allow-credentials? false
+                           :origin-varies?     true
+                           :require-origin?    true
+                           :ignore-failures?   false}
+        expected-response {:status  200
+                           :headers {"Access-Control-Allow-Origin"   "foo"
+                                     "Access-Control-Expose-Headers" "some-header"}
+                           :body    "ok"}]
+    (testing "applies response headers correctly"
+      (testing "synchronous response"
+        (let [handler (sut/wrap-cors (constantly {:status 200 :body "ok"}) cors-policy)]
+          (is (= expected-response
+                 (handler {:method :get :headers {"origin" "foo"}})))))
+      (testing "deferred response"
+        (let [handler  (sut/wrap-cors (constantly (d/future {:status 200 :body "ok"})) cors-policy)
+              response (handler {:method :get :headers {"origin" "foo"}})]
+          (is (d/deferred? response))
+          (is (= expected-response
+                 @response)))))))

--- a/test/com/unbounce/encors/core_test.clj
+++ b/test/com/unbounce/encors/core_test.clj
@@ -131,6 +131,7 @@
                          :origin-varies? false})
           response (apply-cors-policy {:req {}
                                        :app (constantly {:status 200 :headers {} :body "test is alright"})
+                                       :apply-headers apply-ring-headers
                                        :origin nil
                                        :cors-policy policy})]
       (is (= (:status response) 200))
@@ -142,6 +143,7 @@
                          :origin-varies? false})
           response (apply-cors-policy {:req {}
                                        :app (constantly {:status 200 :headers {} :body "test is alright"})
+                                       :apply-headers apply-ring-headers
                                        :origin "http://foobar.com"
                                        :cors-policy policy})]
       (is (= (:status response) 200))
@@ -153,6 +155,7 @@
                          :origin-varies? false})
           response (apply-cors-policy {:req {}
                                        :app (constantly {:status 200 :headers {} :body "test is alright"})
+                                       :apply-headers apply-ring-headers
                                        :origin "http://foobar.com"
                                        :cors-policy policy})]
       (is (= (:status response) 200))


### PR DESCRIPTION
Abstracted out the process of apply headers to a response. 

This allows us to create a version of the middleware which supports aleph & manifold's deferred.